### PR TITLE
fix: エラーコードをクリアして成功時の誤ったエラー表示を防ぐ

### DIFF
--- a/api/core/job_processor.py
+++ b/api/core/job_processor.py
@@ -40,6 +40,7 @@ class JobProcessor:
             
             job.status_code = StatusCode.PDF_COMPLETED
             job.progress = 25
+            job.error_code = None  # エラーコードをクリア
             job.updated_at = datetime.now()
             
             logger.info(f"PDF処理完了: {job_id}, スライド数: {slide_count}")
@@ -103,6 +104,7 @@ class JobProcessor:
             
             job.status_code = StatusCode.DIALOGUE_COMPLETED
             job.progress = 60
+            job.error_code = None  # エラーコードをクリア
             job.updated_at = datetime.now()
             
             logger.info(f"対話生成完了: {job_id}")
@@ -138,6 +140,7 @@ class JobProcessor:
             
             job.status_code = StatusCode.AUDIO_COMPLETED
             job.progress = 85
+            job.error_code = None  # エラーコードをクリア
             job.updated_at = datetime.now()
             
             logger.info(f"音声生成完了: {job_id}")
@@ -169,6 +172,7 @@ class JobProcessor:
             job.status_code = StatusCode.COMPLETED
             job.progress = 100
             job.result_url = f"/api/jobs/{job_id}/download"
+            job.error_code = None  # エラーコードをクリア
             job.updated_at = datetime.now()
             
             logger.info(f"動画作成完了: {job_id}, パス: {video_path}")

--- a/api/main.py
+++ b/api/main.py
@@ -1272,6 +1272,7 @@ async def generate_dialogue_task(job_id: str, additional_prompt: Optional[str] =
         job.status = "dialogue_ready"
         job.status_code = StatusCode.COMPLETED
         job.progress = 100
+        job.error_code = None  # エラーコードをクリアして過去のエラー表示を防ぐ
         job.updated_at = datetime.now()
         
     except Exception as e:
@@ -1408,6 +1409,7 @@ async def generate_complete_video(job_id: str):
         job.status_code = StatusCode.COMPLETED
         job.progress = 100
         job.result_url = f"/api/jobs/{job_id}/download"
+        job.error_code = None  # エラーコードをクリアして過去のエラー表示を防ぐ
         job.updated_at = datetime.now()
         
     except Exception as e:
@@ -1444,6 +1446,7 @@ async def generate_audio_task(
         job.status = "audio_ready"
         job.status_code = StatusCode.COMPLETED
         job.progress = 60
+        job.error_code = None  # エラーコードをクリアして過去のエラー表示を防ぐ
         job.updated_at = datetime.now()
         
     except Exception as e:
@@ -1467,6 +1470,7 @@ async def create_video_task(job_id: str, slide_numbers: Optional[List[int]]):
         job.status_code = StatusCode.COMPLETED
         job.progress = 100
         job.result_url = f"/api/jobs/{job_id}/download"
+        job.error_code = None  # エラーコードをクリアして過去のエラー表示を防ぐ
         job.updated_at = datetime.now()
         
     except Exception as e:


### PR DESCRIPTION
## 概要
動画作成成功時にも「❌ 動画作成中にエラーが発生しました」エラーメッセージが表示される問題を修正

## 問題
- 動画作成が成功した場合でも、過去に設定された `job.error_code` がクリアされないため、フロントエンドで誤ったエラーメッセージが表示される
- `getDisplayError(job)` 関数が `job.error_code` を参照して `t('errors.VIDEO_CREATION_ERROR')` を表示
- 国際化設定: `VIDEO_CREATION_ERROR: "動画作成中にエラーが発生しました"`

## 解決方法
成功時に `job.error_code = None` でエラーコードをクリアする処理を以下の箇所に追加：

### api/main.py
- `generate_dialogue_task`: 対話生成成功時
- `generate_complete_video`: 動画生成成功時  
- `generate_audio_task`: 音声生成成功時
- `create_video_task`: 動画作成成功時

### api/core/job_processor.py
- `process_pdf_sync`: PDF処理成功時
- `generate_dialogue_sync`: 対話生成成功時
- `generate_audio_sync`: 音声生成成功時
- `create_video_sync`: 動画作成成功時

## テスト方法
1. 動画作成を実行し、エラーが発生する状況を作る
2. その後、正常に動画作成を完了させる
3. 成功時に「❌ 動画作成中にエラーが発生しました」が表示されないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)